### PR TITLE
Add viewing key. Useful for verifying balance with view-only wallet

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use std::io::prelude::*;
 
 fn main() { 
     let matches = App::new("piratepaperwallet")
-       .version("1.0")
+       .version("1.1")
        .about("A command line Pirate Sapling paper wallet generator")
        .arg(Arg::with_name("format")
                 .short("f")

--- a/lib/src/paper.rs
+++ b/lib/src/paper.rs
@@ -133,6 +133,20 @@ fn get_address(seed: &[u8], index: u32) -> (String, String, String, json::JsonVa
 // Tests
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn test_full_viewing_key() {
+        use crate::paper::get_address;
+        use hex::FromHex;
+        let hdseed = "023241db228975d6703d34e1cc900c66f63fa4b512894c10faeadbf42e109fc4";
+        // Seed is 32 bytes long.
+        let hdseed_decoded = <[u8; 32]>::from_hex(hdseed).expect("Decoding failed");
+        let expected_addr = "zs19qjkhwjzz03h4p3g0rca50tgeznuhzw9773m8ur64mtaqccyflgdhjsg0fgsxt0m3ljvs73rmc0";
+        let expected_fvk = "zxviews1qvjtyprtqqqqpqyhjrw9eg0hhj7a3mfqae4vfnew6fmsj8a6qlssptk0n4lvz3dhk8p0uu6wvey6u479stpenfjjmsqf8udtjurx8d8ya4rj4l2pf4hxeg63ksf7rqtszg6chm7f00f4z9td7cn6a98sawm3u77hhlpqj6awq5zfjkfz97nmdtdrsdmz44murgm3ck3ra4ph4y9969js5vydh2xqe73z0zu6z2jydq9z2fzgfc5r0f7dyw9qkmw56wpccfc0lcrskmctxn48x";
+        let (addr, fvk, _, _) = get_address(&hdseed_decoded, 0);
+        assert_eq!(addr, expected_addr);
+        assert_eq!(fvk, expected_fvk);
+    }
     
     /**
      * Test the wallet generation and that it is generating the right number and type of addresses

--- a/lib/src/pdf.rs
+++ b/lib/src/pdf.rs
@@ -39,8 +39,9 @@ pub fn save_to_pdf(addresses: &str, filename: &str) {
             current_layer = doc.get_page(page2).add_layer("Layer 3");
         }
 
-        // Add address + private key
+        // Add address + full viewing key + private key
         add_address_to_page(&current_layer, &font, &font_bold, kv["address"].as_str().unwrap(), pos);
+        add_fvk_to_page(&current_layer, &font, &font_bold, kv["viewing_key"].as_str().unwrap(), pos);
         add_pk_to_page(&current_layer, &font, &font_bold, kv["private_key"].as_str().unwrap(), kv["seed"]["HDSeed"].as_str().unwrap(), kv["seed"]["path"].as_str().unwrap(), pos);
 
         // Is the shape stroked? Is the shape closed? Is the shape filled?
@@ -53,7 +54,7 @@ pub fn save_to_pdf(addresses: &str, filename: &str) {
         };
 
 	let line2 = Line {
-            points: vec![(Point::new(Mm(5.0), Mm(207.0)), false), (Point::new(Mm(205.0), Mm(207.0)), false)],
+            points: vec![(Point::new(Mm(5.0), Mm(223.0)), false), (Point::new(Mm(205.0), Mm(223.0)), false)],
             is_closed: true,
             has_fill: false,
             has_stroke: true,
@@ -128,14 +129,33 @@ fn add_address_to_page(current_layer: &PdfLayerReference, font: &IndirectFontRef
     let (scaledimg, finalsize) = qrcode_scaled(address, 10);
 
     //         page_height  top_margin  vertical_padding  position       
-    let ypos = 297.0        - 5.0       - 77.0            - (140.0 * pos as f64);
+    let ypos = 297.0        - 5.0       - 57.0            - (140.0 * pos as f64);
     add_qrcode_image_to_page(current_layer, scaledimg, finalsize, Mm(10.0), Mm(ypos));
 
-    current_layer.use_text("ARRR Address (Sapling)", 14, Mm(55.0), Mm(ypos+27.5), &font_bold);
+    current_layer.use_text("ARRR Receiving Address (Sapling)", 14, Mm(55.0), Mm(ypos+27.5), &font_bold);
     
     let strs = split_to_max(&address, 39, 39);  // No spaces, so user can copy the address
     for i in 0..strs.len() {
         current_layer.use_text(strs[i].clone(), 12, Mm(55.0), Mm(ypos+20.0-((i*5) as f64)), &font);
+    }
+}
+
+/**
+ * Add the full viewing key (aka viewing key) section to the PDF.
+ */
+fn add_fvk_to_page(current_layer: &PdfLayerReference, font: &IndirectFontRef, font_bold: &IndirectFontRef, fvk: &str, pos: u32) {
+    let (scaledimg, finalsize) = qrcode_scaled(fvk, 10);
+
+    //         page_height  top_margin  vertical_padding  position
+    let ypos = 297.0        - 5.0       - 150.0            - (140.0 * pos as f64);
+    add_qrcode_image_to_page(current_layer, scaledimg, finalsize, Mm(10.0), Mm(ypos));
+
+    current_layer.use_text("Viewing Key (for view-only wallet)", 14, Mm(75.0), Mm(ypos+51.0), &font_bold);
+    current_layer.use_text("Keep private!", 14, Mm(75.0), Mm(ypos+45.0), &font_bold);
+
+    let strs = split_to_max(&fvk, 45, 45);  // No spaces, so user can copy the fvk
+    for i in 0..strs.len() {
+        current_layer.use_text(strs[i].clone(), 12, Mm(75.0), Mm(ypos+35.0-((i*5) as f64)), &font);
     }
 }
 
@@ -147,7 +167,7 @@ fn add_pk_to_page(current_layer: &PdfLayerReference, font: &IndirectFontRef, fon
 
     //         page_height  top_margin  vertical_padding  position       
     let ypos = 297.0        - 5.0       - 242.0           - (140.0 * pos as f64);    
-    add_qrcode_image_to_page(current_layer, scaledimg, finalsize, Mm(145.0), Mm(ypos-17.5));
+    add_qrcode_image_to_page(current_layer, scaledimg, finalsize, Mm(138.0), Mm(ypos-17.5));
 
     current_layer.use_text("Private Key", 14, Mm(10.0), Mm(ypos+32.5), &font_bold);
     let strs = split_to_max(&pk, 45, 45);   // No spaces, so user can copy the private key


### PR DESCRIPTION
### Summary
Before this, you could not verify the balance of your paper wallet AND keep it cold. Now you can with view-only wallets + viewingkey.

The viewingkey cannot spend, but it should be kept private. Anyone with the viewingkey can see the receiving address and balance.

### PDF output
Note, the bottom of the page has whitespace/margin. It was cropped away due to the large screenshot.

Obviously, no one should use the throw-away wallets listed here.

![piratepaperwallet with viewingkey Screenshot from 2021-01-17 01-46-28](https://user-images.githubusercontent.com/77570852/105002374-079cd180-59e6-11eb-80b0-17d70a3314b7.png)

### Testing

This is how I tested it.

Created .pdf paper wallet and printed it on paper.

Sent 0.0004 ARRR to the receiving address.

Scanned the viewingkey QR with smartphone and imported it into an empty wallet:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_importviewingkey zxviews1q0dtp5gvqqqqpq9nfhwu0swksf2c9zweu89mrpff69kt6v592ze3hae7maffxaf2922m3hgce9z3mymt2qz5yrqswhah6524k9pw5ymsfme5pqgevvqaj9y4qwneyjfqrrxxhaz3mmd34ta79v6ur90ugjrsc78e0at8gpg8m9jdlavpgyy8swr7x8cyrgc5sjy2v2zwqj208rryy0gxd7muu24ah3x7kmn7fja5w9z6qswn5f7qhtxqf2zrufq3ch9vpef6e8lljscae246l yes 1228200
{
  "type": "sapling",
  "address": "zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw"
}
```

Verified the balance of paper wallet with viewing key imported:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getbalance zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw
0.00040000
```

Attempted to spend while having only the viewing key. It should fail, and it does:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_sendmany zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw '[{"address": "zs1rpvjthktxwun99gkk0ytxrvkawzyx6xxfhun03aqlqkxuqek8gcx073k5a6gvedkgpw25l3ghck", "amount": 0.0002}]'
error code: -5
error message:
From address does not belong to this node, zaddr spending key not found.
```

### Now test the private key...

Created a new, blank wallet. Verified it has the initial address only (`true`: list view-only wallets too):
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_listaddresses true
[
  "zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm"
]
```

Imported the paper wallet's private key:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_importkey secret-extended-key-main1q0dtp5gvqqqqpq9nfhwu0swksf2c9zweu89mrpff69kt6v592ze3hae7maffxaf29fyw9rl0ya8sgyncyr0ak7nalldr0c09jdurj7rwru2rrmn3nn7qt7um9w6m3rfy0rq6dkk36alsq98c8xwwwpmfg8hajde76gq8r2gvm9jdlavpgyy8swr7x8cyrgc5sjy2v2zwqj208rryy0gxd7muu24ah3x7kmn7fja5w9z6qswn5f7qhtxqf2zrufq3ch9vpef6e8lljsch3gs70 yes 1228200
```

Now there's 2 addresses with spending key (1st one is the paper wallet):
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_listaddresses
[
  "zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw",
  "zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm"
]
```

Verified the balance of the paper wallet:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getbalance zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw
0.00040000
```

Spent from the paper wallet:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_sendmany zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw '[{"address": "zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm", "amount": 0.0002}]'
opid-2c1a73ad-28e3-41cd-91f4-1ef90558ee4e
```

Verified the transaction:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getoperationstatus '["opid-2c1a73ad-28e3-41cd-91f4-1ef90558ee4e"]'
[
  {
    "id": "opid-2c1a73ad-28e3-41cd-91f4-1ef90558ee4e",
    "status": "success",
    "creation_time": 1610948077,
    "result": {
      "txid": "8247e1277167a8deaf5cb9efd896332e0650bcc1471bf732bec0ca128a7b4bdc"
    },
    "execution_secs": 2.866045869,
    "method": "z_sendmany",
    "params": {
      "fromaddress": "zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw",
      "amounts": [
        {
          "address": "zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm",
          "amount": 0.0002
        }
      ],
      "minconf": 1,
      "fee": 0.0001
    }
  }
]
```

Waited for 1 confirmation:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_listreceivedbyaddress zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm
[
  {
    "txid": "8247e1277167a8deaf5cb9efd896332e0650bcc1471bf732bec0ca128a7b4bdc",
    "amount": 0.00020000,
    "memo": "f600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "outindex": 0,
    "rawconfirmations": 1,
    "confirmations": 1,
    "change": false
  }
]
```

Verified the balance on receiving wallet:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getbalance zs19k59upjlxaw7ftg9t4k4pvx9uwdh95qr4vkmyaxmgssal6tsmaa2val5dnu9khwapm3qcc2cnsm
0.00020000
```

Verified balance on paper wallet has gone down by 0.0002 + 0.0001 fee:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getbalance zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw
0.00010000
```

Stopped pirated. Switched back to view-only wallet and verified new balance of the paper wallet:

View-only wallets do not appear by default:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_listaddresses
[
  "zs1rpvjthktxwun99gkk0ytxrvkawzyx6xxfhun03aqlqkxuqek8gcx073k5a6gvedkgpw25l3ghck"
]
```

Include view-only wallets with 'true':
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_listaddresses true
[
  "zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw",
  "zs1rpvjthktxwun99gkk0ytxrvkawzyx6xxfhun03aqlqkxuqek8gcx073k5a6gvedkgpw25l3ghck",
  "zs1skwxmcuvcakt6w0t64nrxh5gkqt2yua3yf39z78w74pxl744eujjvac6r7qg677gkdv26jk4q55"
]
```

Verified view-only paper wallet has the current balance of 0.0001:
```
@crab:~/workspace/piratechain/pirate_cli$ ./pirate-cli z_getbalance zs1pwvfx37vfukkhps3ed285dq86283jslqt5yplmgmtdqta76t7qr2yzd8vhfzyv2phxlzw0x3elw
0.00010000
```

### Windows Binary

Note, I don't have a Mac to test with.

Built Windows binary:
```
plankton@vcrab:~/workspace/github.com/sir-plankton/piratepaperwallet/cli$ docker run --rm -v $(pwd)/..:/opt/zecpaperwallet rust/zecpaperwallet:v0.1 bash -c "cd /opt/zecpaperwallet/cli && cargo build --release --target x86_64-pc-windows-gnu"
```

scp piratepaperwallet.exe to Windows computer. Run in powershell:
```
PS S:\virtual_machines> .\piratepaperwallet.exe --format pdf .\paperwallet_windows.pdf
Provide additional entropy for generating random numbers. Type in a string of random characters (longer the better), press [ENTER] when done

Generating 1 Sapling addresses.........[OK]
Writing ".\\paperwallet_windows.pdf" as a PDF file...[OK]
```

Verified/opened .pdf in Windows.

Ran again with no user entropy and verified receive address was different from the first .pdf (system entropy was used).

### Unit Test

Got seed, receiving address, and viewingkey from a throw-away paper wallet.
Main purpose of `test_full_viewing_key` is to ensure the 2nd element of the tuple returned by get_address() is the viewingkey.

I don't know why the existing tests fail, but my test (test_full_viewing_key) is OK:
```
running 5 tests
test pdf::tests::test_split ... ok
test paper::tests::test_full_viewing_key ... ok
thread 'paper::tests::test_nohd' panicked at 'assertion failed: j[i]["address"].as_str().unwrap().starts_with("ztestsapling")', src/paper.rs:206:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test paper::tests::test_nohd ... FAILED
thread 'paper::tests::test_wallet_generation' panicked at 'assertion failed: j[i]["address"].as_str().unwrap().starts_with("ztestsapling")', src/paper.rs:175:13
test paper::tests::test_wallet_generation ... FAILED
test paper::tests::test_address_derivation_main ... ok

failures:

failures:
    paper::tests::test_nohd
    paper::tests::test_wallet_generation

test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

### JSON Output

Also tested json output:
```
~/workspace/github.com/sir-plankton/piratepaperwallet/cli# ./target/release/piratepaperwallet
Provide additional entropy for generating random numbers. Type in a string of random characters (longer the better), press [ENTER] when done

Generating 1 Sapling addresses.........[OK]
[
  {
    "num": 0,
    "address": "zs1qj220n3zpgfj329u05p0ceyjnp9v5cemh7amff94m02gtqj9xyl60w6w787v6fyx82h265d407g",
    "viewing_key": "zxviews1qv3edsmwqqqqpq9znu2hwh2uqqg4pmf7gw2rz8qnwv2f6yn3ctmz9xwj78gn4m4nr0vkx2y06qzcze69v3yecruyp7gzf0nnv7e3d4hs5vxeghlp9vlfy9zwm54zsmmzqdlsj2yluxup2lnrjpdueh7lxlsx7khcexq5hzpyj90vu0zc6k37ddh43ctz4mh2wazk0f7r6m555aap34jk6axpavxxgrqd22l9xpskv82cp9nnlkasdy7ll9y2cf4k6rd2f0htakfr4zcnxefvd",
    "private_key": "secret-extended-key-main1qv3edsmwqqqqpq9znu2hwh2uqqg4pmf7gw2rz8qnwv2f6yn3ctmz9xwj78gn4m4nr02vsnh7hfp6qzsmjee6kyrj069xk32fd4wwv0jyaqarc04vhh4s6dxc2rmn8tzcpgzyv7gvza66unl3rlguxw5na7xuxerhmk3j0us8j90vu0zc6k37ddh43ctz4mh2wazk0f7r6m555aap34jk6axpavxxgrqd22l9xpskv82cp9nnlkasdy7ll9y2cf4k6rd2f0htakfr4zcf3je7g",
    "seed": {
      "HDSeed": "6b3ef5085ce20c544b9cdd164176d253a863c3fd8154aa9b1b2d725f58bd0e45",
      "path": "m/32'/133'/0'"
    }
  }
]
```

<end of testing>
